### PR TITLE
Updated Build files to streamline Twig changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.16 )
 
-project( antelope-spring )
+project( twig-spring )
 include(CTest)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 4. [Build and Install from Source](#build-and-install-from-source)
 5. [Bash Autocomplete](#bash-autocomplete)
 
-Spring is a C++ implementation of the [Antelope](https://github.com/AntelopeIO) protocol with support for Savanna consensus. It contains blockchain node software and supporting tools for developers and node operators.
+Twig Spring is a C++ implementation of the [Antelope](https://github.com/AntelopeIO) protocol with support for Savanna consensus. It contains blockchain node software and supporting tools for developers and node operators.
 
 ## Branches
-The `main` branch is the development branch; do not use it for production. Refer to the [release page](https://github.com/AntelopeIO/spring/releases) for current information on releases, pre-releases, and obsolete releases, as well as the corresponding tags for those releases.
+The `main` branch is the development branch; do not use it for production. Refer to the [release page](https://github.com/two-sticks/twig-blockchain/releases) for current information on releases, pre-releases, and obsolete releases, as well as the corresponding tags for those releases.
 
 ## Supported Operating Systems
 We currently support the following operating systems.
@@ -25,7 +25,7 @@ cat /etc/upstream-release/lsb-release
 Your best bet is to follow the instructions for your Ubuntu base, but we make no guarantees.
 
 ## Binary Installation
-This is the fastest way to get started. From the [latest release](https://github.com/AntelopeIO/spring/releases/latest) page, download a binary for one of our [supported operating systems](#supported-operating-systems), or visit the [release tags](https://github.com/AntelopeIO/spring/releases) page to download a binary for a specific version of Spring.
+This is the fastest way to get started. From the [latest release](https://github.com/two-sticks/twig-blockchain/releases/latest) page, download a binary for one of our [supported operating systems](#supported-operating-systems), or visit the [release tags](https://github.com/two-sticks/twig-blockchain/releases) page to download a binary for a specific version of Spring.
 
 Once you have a `*.deb` file downloaded for your version of Ubuntu, you can install it as follows:
 ```bash
@@ -68,11 +68,11 @@ cd ~/Downloads
 ```
 Clone Spring using either HTTPS...
 ```bash
-git clone --recursive https://github.com/AntelopeIO/spring.git
+git clone --recursive https://github.com/two-sticks/twig-blockchain.git
 ```
 ...or SSH:
 ```bash
-git clone --recursive git@github.com:AntelopeIO/spring.git
+git clone --recursive git@github.com:two-sticks/twig-blockchain.git
 ```
 
 > ℹ️ **HTTPS vs. SSH Clone** ℹ️  
@@ -84,7 +84,7 @@ cd spring
 ```
 
 ### Step 2 - Checkout Release Tag or Branch
-Choose which [release](https://github.com/AntelopeIO/spring/releases) or [branch](#branches) you would like to build, then check it out. If you are not sure, use the [latest release](https://github.com/AntelopeIO/spring/releases/latest). For example, if you want to build release 1.0.1 then you would check it out using its tag, `v1.0.1`. In the example below, replace `v0.0.0` with your selected release tag accordingly:
+Choose which [release](https://github.com/two-sticks/twig-blockchain/releases) or [branch](#branches) you would like to build, then check it out. If you are not sure, use the [latest release](https://github.com/two-sticks/twig-blockchain/releases). For example, if you want to build release 1.0.1 then you would check it out using its tag, `v1.0.1`. In the example below, replace `v0.0.0` with your selected release tag accordingly:
 ```bash
 git fetch --all --tags
 git checkout v0.0.0
@@ -208,7 +208,7 @@ Once you have [built](#step-3---build-the-source-code) Spring and [tested](#step
 We recommend installing the binary package you just built. Navigate to your Spring build directory in a terminal and run this command:
 ```bash
 sudo apt-get update
-sudo apt-get install -y ./spring_*.deb
+sudo apt-get install -y ./twig-spring_*.deb
 ```
 
 It is also possible to install using `make` instead:

--- a/package.cmake
+++ b/package.cmake
@@ -55,7 +55,7 @@ if(ENABLE_SPRING_DEV_DEB)
    list(APPEND CPACK_COMPONENTS_ALL "dev")
 endif()
 
-#enable per component packages for .deb; ensure main package is just "antelope-spring", not "antelope-spring-base", and make the dev package have "antelope-spring-dev" at the front not the back
+#enable per component packages for .deb; ensure main package is just "twig-spring", not "twig-spring-base", and make the dev package have "twig-spring-dev" at the front not the back
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_BASE_PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
 set(CPACK_DEBIAN_BASE_FILE_NAME "${CPACK_DEBIAN_FILE_NAME}.deb")

--- a/tools/reproducible.Dockerfile
+++ b/tools/reproducible.Dockerfile
@@ -104,7 +104,7 @@ ARG SPRING_BUILD_JOBS
 COPY / /__w/spring/spring
 RUN cmake -S /__w/spring/spring -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -GNinja && \
     cmake --build build -t package -- ${SPRING_BUILD_JOBS:+-j$SPRING_BUILD_JOBS} && \
-    /__w/spring/spring/tools/tweak-deb.sh build/antelope-spring_*.deb
+    /__w/spring/spring/tools/tweak-deb.sh build/twig-spring_*.deb
 
 FROM scratch AS exporter
 COPY --from=build /build/*.deb /build/*.tar.* /


### PR DESCRIPTION
Updated the files involved in the build process and readme, to reflect twig-spring instead of antelope-spring. This will streamline the installs for operators of twig. 